### PR TITLE
Fix example from developer startup and update documentation

### DIFF
--- a/docs/developer/DEVELOPMENT.md
+++ b/docs/developer/DEVELOPMENT.md
@@ -97,7 +97,13 @@ if err := generator.RegisterResource(&newtype.NewType{}); err != nil {
 }
 ```
 
-### Step 3: Regenerate Code
+### Step 3: Register Resource Prefix
+Add to `pkg/resources/main.go`:
+```go
+RegisterResourcePrefix("NewType", "nt")
+```
+
+### Step 4: Regenerate Code
 ```bash
 make dev
 ```
@@ -109,7 +115,47 @@ This automatically generates:
 - Storage operations
 - Request/response types
 
-### Step 4: Generate Reconciler (Optional)
+### Step 5: Test the code
+Start server
+```bash
+./bin/server
+```
+
+Add a new device to ensure it was successfully created
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"name": "MyTestObject", "spec": {"fieldOne": "hello", "fieldTwo": "world"}}' \
+  http://localhost:8080/newtypes
+```
+
+You should get something like this:
+```json
+{
+  "apiVersion": "v1",
+  "kind": "NewType",
+  "schemaVersion": "v1",
+  "metadata": {
+    "name": "MyTestObject",
+    "uid": "nt-d67c06b1",
+    "createdAt": "2025-10-03T14:02:00.257301-07:00",
+    "updatedAt": "2025-10-03T14:02:00.257301-07:00"
+  },
+  "spec": {},
+  "status": {
+    "conditions": [
+      {
+        "type": "Created",
+        "status": "True",
+        "reason": "NewTypeCreated",
+        "message": "NewType has been created",
+        "lastTransitionTime": "2025-10-03T14:02:00.257302-07:00"
+      }
+    ]
+  }
+}
+```
+
+### Step 5: Generate Reconciler (Optional)
 
 If your resource needs reconciliation logic:
 
@@ -123,7 +169,7 @@ This generates:
 - Updates `registration_generated.go` - Automatic registration
 - Updates `event_handlers_generated.go` - Event handler registry
 
-### Step 5: Implement Reconciliation Logic (Optional)
+### Step 6: Implement Reconciliation Logic (Optional)
 
 Edit the stub method in `pkg/reconcilers/newtype_reconciler_generated.go`:
 

--- a/docs/developer/DEVELOPMENT.md
+++ b/docs/developer/DEVELOPMENT.md
@@ -155,7 +155,7 @@ You should get something like this:
 }
 ```
 
-### Step 5: Generate Reconciler (Optional)
+### Step 6: Generate Reconciler (Optional)
 
 If your resource needs reconciliation logic:
 
@@ -169,7 +169,7 @@ This generates:
 - Updates `registration_generated.go` - Automatic registration
 - Updates `event_handlers_generated.go` - Event handler registry
 
-### Step 6: Implement Reconciliation Logic (Optional)
+### Step 7: Implement Reconciliation Logic (Optional)
 
 Edit the stub method in `pkg/reconcilers/newtype_reconciler_generated.go`:
 

--- a/internal/storage/file_backend.go
+++ b/internal/storage/file_backend.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 
+	"github.com/openchami/inventory/pkg/resources"
 	"github.com/openchami/inventory/pkg/versioning"
 )
 
@@ -50,6 +52,123 @@ type FileBackend struct {
 	mu              sync.RWMutex
 	closed          bool
 	versionRegistry *versioning.VersionRegistry // Version registry for conversion support
+}
+
+type genericFileStorage struct {
+	backend      *FileBackend
+	resourceType string
+}
+
+// Load implements GenericStorage.Load
+func (g *genericFileStorage) Load(ctx context.Context, uid string) (interface{}, error) {
+	return g.backend.Load(ctx, g.resourceType, uid)
+}
+
+// LoadAll implements GenericStorage.LoadAll
+func (g *genericFileStorage) LoadAll(ctx context.Context) ([]interface{}, error) {
+	rawMessages, err := g.backend.LoadAll(ctx, g.resourceType)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]interface{}, len(rawMessages))
+	for i, v := range rawMessages {
+		results[i] = v
+	}
+	return results, nil
+}
+
+// Delete implements GenericStorage.Delete
+func (g *genericFileStorage) Delete(ctx context.Context, uid string) error {
+	return g.backend.Delete(ctx, g.resourceType, uid)
+}
+
+// Exists implements GenericStorage.Exists
+func (g *genericFileStorage) Exists(ctx context.Context, uid string) (bool, error) {
+	return g.backend.Exists(ctx, g.resourceType, uid)
+}
+
+// List implements GenericStorage.List
+func (g *genericFileStorage) List(ctx context.Context) ([]string, error) {
+	return g.backend.List(ctx, g.resourceType)
+}
+
+// LoadWithVersion implements GenericStorage.LoadWithVersion
+func (g *genericFileStorage) LoadWithVersion(ctx context.Context, uid string, version string) (interface{}, string, error) {
+	return g.backend.LoadWithVersion(ctx, g.resourceType, uid, version)
+}
+
+// LoadAllWithVersion implements GenericStorage.LoadAllWithVersion
+func (g *genericFileStorage) LoadAllWithVersion(ctx context.Context, version string) ([]interface{}, error) {
+	rawMessages, err := g.backend.LoadAllWithVersion(ctx, g.resourceType, version)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]interface{}, len(rawMessages))
+	for i, v := range rawMessages {
+		results[i] = v
+	}
+	return results, nil
+}
+
+func (g *genericFileStorage) Save(ctx context.Context, resource interface{}) error {
+	val := reflect.ValueOf(resource)
+	if val.Kind() != reflect.Ptr {
+		return fmt.Errorf("resource must be a pointer to a struct, but got %T", resource)
+	}
+	elem := val.Elem()
+
+	// Access the nested 'Metadata' field
+	metadataField := elem.FieldByName("Metadata")
+	if !metadataField.IsValid() {
+		return fmt.Errorf("resource of type %T is missing the 'Metadata' field", resource)
+	}
+
+	// Now, access the 'UID' field within the Metadata struct
+	uidField := metadataField.FieldByName("UID")
+	if !uidField.IsValid() || !uidField.CanSet() {
+		return fmt.Errorf("resource of type %T is missing a settable 'UID' field within its Metadata", resource)
+	}
+
+	// Generate and set the UID
+	uid, err := resources.GenerateUIDForResource(g.resourceType)
+	if err != nil {
+		return fmt.Errorf("failed to generate UID: %w", err)
+	}
+	uidField.SetString(uid)
+
+	// Marshal the full resource object
+	data, err := json.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource: %w", err)
+	}
+
+	// Call the underlying backend's save method
+	return g.backend.Save(ctx, g.resourceType, uid, data)
+}
+
+// SaveWithVersion implements GenericStorage.SaveWithVersion
+func (g *genericFileStorage) SaveWithVersion(ctx context.Context, resource interface{}, version string) error {
+	val := reflect.ValueOf(resource)
+	if val.Kind() != reflect.Ptr {
+		return fmt.Errorf("resource must be a pointer to a struct, but got %T", resource)
+	}
+	elem := val.Elem()
+
+	// Access the nested 'Metadata.UID' field
+	uidField := elem.FieldByName("Metadata").FieldByName("UID")
+	if !uidField.IsValid() {
+		return fmt.Errorf("resource of type %T is missing the 'Metadata.UID' field", resource)
+	}
+	uid := uidField.String()
+	if uid == "" {
+		return fmt.Errorf("resource UID is empty, cannot save with version")
+	}
+
+	data, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+	return g.backend.SaveWithVersion(ctx, g.resourceType, uid, data, version)
 }
 
 // NewFileBackend creates a new file-based storage backend.
@@ -620,4 +739,11 @@ func (f *FileBackend) SaveWithVersion(ctx context.Context, resourceType, uid str
 
 	// Save in storage version
 	return f.Save(ctx, resourceType, uid, json.RawMessage(storageData))
+}
+
+func (f *FileBackend) ForType(resourceType string) GenericStorage {
+	return &genericFileStorage{
+		backend:      f,
+		resourceType: resourceType,
+	}
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -43,10 +43,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/openchami/inventory/pkg/resources/bmc"
-	"github.com/openchami/inventory/pkg/resources/boot"
 	"github.com/openchami/inventory/pkg/resources/fru"
-	"github.com/openchami/inventory/pkg/resources/node"
 )
 
 // Common storage errors
@@ -663,30 +660,6 @@ func (s *resourceStorage[T]) SaveWithVersion(ctx context.Context, resource inter
 	}
 
 	return nil
-}
-
-// Convenience functions for getting type-safe storage for each resource type
-// These functions provide a simple way to get properly configured storage
-// for each resource type without having to specify generics manually.
-
-// GetBMCStorage returns type-safe storage for BMC resources
-func GetBMCStorage(backend StorageBackend) ResourceStorage[*bmc.BMC] {
-	return NewResourceStorage[*bmc.BMC](backend, "BMC")
-}
-
-// GetNodeStorage returns type-safe storage for Node resources
-func GetNodeStorage(backend StorageBackend) ResourceStorage[*node.Node] {
-	return NewResourceStorage[*node.Node](backend, "Node")
-}
-
-// GetFRUStorage returns type-safe storage for FRU resources
-func GetFRUStorage(backend StorageBackend) ResourceStorage[*fru.FRU] {
-	return NewResourceStorage[*fru.FRU](backend, "FRU")
-}
-
-// GetBootConfigurationStorage returns type-safe storage for BootConfiguration resources
-func GetBootConfigurationStorage(backend StorageBackend) ResourceStorage[*boot.BootConfiguration] {
-	return NewResourceStorage[*boot.BootConfiguration](backend, "BootConfiguration")
 }
 
 // GetFRUInventorySnapshotStorage returns type-safe storage for FRUInventorySnapshot resources

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -298,6 +298,33 @@ type StorageBackend interface {
 	//   data, _ := json.Marshal(bmcV2)
 	//   err := backend.SaveWithVersion(ctx, "BMC", bmc.GetUID(), data, "v2beta1")
 	SaveWithVersion(ctx context.Context, resourceType, uid string, data json.RawMessage, version string) error
+
+	// ForType returns a type-safe GenericStorage interface scoped to a single resource type.
+	//
+	// This method acts as a factory, creating a specialized storage handler from a
+	// generic backend. This allows for cleaner, type-safe operations without needing
+	// to pass the resourceType string to every storage call.
+	//
+	// Parameters:
+	//   - resourceType: The type of resource (e.g., "BMC", "Node", "FRU")
+	//
+	// Returns:
+	//   - GenericStorage: A storage interface that is pre-configured to operate
+	//     only on the specified resource type.
+	//
+	// Behavior:
+	//   - Returns a new storage handler or wrapper.
+	//   - All operations on the returned interface (e.g., Load, Save) will
+	//     implicitly use the provided resourceType.
+	//   - The returned handler is safe for concurrent use.
+	//
+	// Example:
+	//   // Get a specific storage handler for BMCs
+	//   bmcStorage := backend.ForType("BMC")
+	//
+	//   // Now, you can perform operations without specifying "BMC" every time
+	//   allBMCs, err := bmcStorage.LoadAll(ctx)
+	ForType(resourceType string) GenericStorage
 }
 
 // ResourceStorage provides type-safe storage operations for a specific resource type.

--- a/pkg/codegen/generator.go
+++ b/pkg/codegen/generator.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"go/format"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -117,24 +118,8 @@ func (g *Generator) RegisterResource(resourceType interface{}) error {
 	var packageImport, typePrefix string
 
 	// Map the new package structure
-	switch {
-	case strings.Contains(pkgPath, "/bmc"):
-		packageImport = "github.com/openchami/inventory/pkg/resources/bmc"
-		typePrefix = "bmc"
-	case strings.Contains(pkgPath, "/node"):
-		packageImport = "github.com/openchami/inventory/pkg/resources/node"
-		typePrefix = "node"
-	case strings.Contains(pkgPath, "/fru"):
-		packageImport = "github.com/openchami/inventory/pkg/resources/fru"
-		typePrefix = "fru"
-	case strings.Contains(pkgPath, "/boot"):
-		packageImport = "github.com/openchami/inventory/pkg/resources/boot"
-		typePrefix = "boot"
-	default:
-		// Fallback for resources package
-		packageImport = "github.com/openchami/inventory/pkg/resources"
-		typePrefix = "resources"
-	}
+	packageImport = pkgPath
+	typePrefix = path.Base(pkgPath)
 
 	// Initialize default version metadata
 	defaultVersion := versioning.SchemaVersion{

--- a/pkg/codegen/templates/storage.go.tmpl
+++ b/pkg/codegen/templates/storage.go.tmpl
@@ -87,9 +87,20 @@ func LoadAll{{.StorageName}}s() ([]{{.TypeName}}, error) {
 // This is a convenience function that uses storage.DefaultBackend.
 // For more control, use storage.Get{{.Name}}Storage(backend).Load(ctx, uid).
 func Load{{.StorageName}}(uid string) ({{.TypeName}}, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.Load(context.Background(), uid)
+    ensureDefaultBackend()
+    storage := Get{{.Name}}Storage(DefaultBackend)
+
+    res, err := storage.Load(context.Background(), uid)
+    if err != nil {
+        return nil, err
+    }
+
+    typedRes, ok := res.({{.TypeName}})
+    if !ok {
+        return nil, fmt.Errorf("unexpected type: got %T, want {{.TypeName}}", res)
+    }
+
+    return typedRes, nil
 }
 
 // Save{{.StorageName}} stores a {{.Name}} resource using the default backend.
@@ -207,9 +218,24 @@ func Load{{.StorageName}}WithVersion(uid string, version string) (interface{}, s
 //       }
 //   }
 func LoadAll{{.StorageName}}sWithVersion(version string) ([]interface{}, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.LoadAllWithVersion(context.Background(), version)
+    ensureDefaultBackend()
+    storage := Get{{.Name}}Storage(DefaultBackend)
+
+    results, err := storage.LoadAll(context.Background())
+    if err != nil {
+        return nil, err
+    }
+
+    typedResults := make([]{{.TypeName}}, len(results))
+    for i, res := range results {
+        typedRes, ok := res.({{.TypeName}})
+        if !ok {
+            return nil, fmt.Errorf("unexpected type in slice at index %d: got %T, want {{.TypeName}}", i, res)
+        }
+        typedResults[i] = typedRes
+    }
+
+    return typedResults, nil
 }
 
 // Save{{.StorageName}}WithVersion stores a {{.Name}} resource with version information.

--- a/pkg/codegen/templates/storage.go.tmpl
+++ b/pkg/codegen/templates/storage.go.tmpl
@@ -20,285 +20,12 @@ import (
 	"fmt"
 	"sync"
 
-	"{{.ModulePath}}/pkg/resources/bmc"
-	"{{.ModulePath}}/pkg/resources/node"
-	"{{.ModulePath}}/pkg/resources/fru"
-	"{{.ModulePath}}/pkg/resources/boot"
+	{{range .Resources}}
+	"{{.Package}}"
+	{{end}}
 )
 
-// DefaultBackend is the storage backend used by the package-level convenience functions.
-// This can be set during application initialization to use any StorageBackend implementation.
-//
-// Example:
-//   // Use file-based storage
-//   storage.DefaultBackend, _ = storage.NewFileBackend("./inventory")
-//
-//   // Use database storage (hypothetical)
-//   storage.DefaultBackend = storage.NewDatabaseBackend(dbConfig)
-var DefaultBackend StorageBackend
-
-// initOnce ensures DefaultBackend is initialized only once
-var initOnce sync.Once
-
-// ensureDefaultBackend initializes DefaultBackend if it hasn't been set
-func ensureDefaultBackend() {
-	initOnce.Do(func() {
-		if DefaultBackend == nil {
-			// Default to file-based storage in "inventory" directory
-			backend, err := NewFileBackend("inventory")
-			if err != nil {
-				panic(fmt.Sprintf("failed to initialize default storage backend: %v", err))
-			}
-			DefaultBackend = backend
-		}
-	})
-}
-
-// Package-level convenience functions for each resource type.
-// These functions use the DefaultBackend and provide a simple API
-// for applications that don't need to manage multiple backends.
-
-{{range .Resources}}
-// {{.Name}} storage operations using DefaultBackend
-
-// LoadAll{{.StorageName}}s retrieves all {{.Name}} resources using the default backend.
-//
-// Returns:
-//   - []{{.TypeName}}: Slice of {{.Name}} resources
-//   - error: Any error that occurred during loading
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).LoadAll(ctx).
-func LoadAll{{.StorageName}}s() ([]{{.TypeName}}, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.LoadAll(context.Background())
-}
-
-// Load{{.StorageName}} retrieves a single {{.Name}} resource by UID using the default backend.
-//
-// Parameters:
-//   - uid: Unique identifier of the {{.Name}} resource
-//
-// Returns:
-//   - {{.TypeName}}: The {{.Name}} resource
-//   - error: ErrNotFound if resource doesn't exist, other errors for failures
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).Load(ctx, uid).
-func Load{{.StorageName}}(uid string) ({{.TypeName}}, error) {
-    ensureDefaultBackend()
-    storage := Get{{.Name}}Storage(DefaultBackend)
-
-    res, err := storage.Load(context.Background(), uid)
-    if err != nil {
-        return nil, err
-    }
-
-    typedRes, ok := res.({{.TypeName}})
-    if !ok {
-        return nil, fmt.Errorf("unexpected type: got %T, want {{.TypeName}}", res)
-    }
-
-    return typedRes, nil
-}
-
-// Save{{.StorageName}} stores a {{.Name}} resource using the default backend.
-//
-// Parameters:
-//   - {{camelCase .Name}}: The {{.Name}} resource to save
-//
-// Returns:
-//   - error: Any error that occurred during saving
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).Save(ctx, resource).
-func Save{{.StorageName}}({{camelCase .Name}} {{.TypeName}}) error {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.Save(context.Background(), {{camelCase .Name}})
-}
-
-// Delete{{.StorageName}} removes a {{.Name}} resource by UID using the default backend.
-//
-// Parameters:
-//   - uid: Unique identifier of the {{.Name}} resource
-//
-// Returns:
-//   - error: ErrNotFound if resource doesn't exist, other errors for failures
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).Delete(ctx, uid).
-func Delete{{.StorageName}}(uid string) error {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.Delete(context.Background(), uid)
-}
-
-// Exists{{.StorageName}} checks if a {{.Name}} resource exists using the default backend.
-//
-// Parameters:
-//   - uid: Unique identifier of the {{.Name}} resource
-//
-// Returns:
-//   - bool: true if the resource exists
-//   - error: Any error that occurred during the check
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).Exists(ctx, uid).
-func Exists{{.StorageName}}(uid string) (bool, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.Exists(context.Background(), uid)
-}
-
-// List{{.StorageName}}UIDs returns UIDs of all {{.Name}} resources using the default backend.
-//
-// Returns:
-//   - []string: Array of {{.Name}} resource UIDs
-//   - error: Any error that occurred during listing
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).List(ctx).
-func List{{.StorageName}}UIDs() ([]string, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.List(context.Background())
-}
-
-// Load{{.StorageName}}WithVersion retrieves a single {{.Name}} resource in the requested schema version.
-//
-// Parameters:
-//   - uid: Unique identifier of the {{.Name}} resource
-//   - version: Requested schema version (e.g., "v1", "v2beta1")
-//
-// Returns:
-//   - interface{}: The {{.Name}} resource in requested version (caller must type assert)
-//   - string: Actual version returned
-//   - error: ErrNotFound if resource doesn't exist, error if version not supported
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).LoadWithVersion(ctx, uid, version).
-//
-// Example:
-//   resource, version, err := storage.Load{{.StorageName}}WithVersion("{{toLower .Name}}-123", "v2beta1")
-//   if err != nil {
-//       return err
-//   }
-//   // Type assert to expected version type
-//   if {{camelCase .Name}}V2, ok := resource.(*{{toLower .PackageAlias}}v2beta1.{{.Name}}); ok {
-//       // Use v2beta1 resource
-//   }
-func Load{{.StorageName}}WithVersion(uid string, version string) (interface{}, string, error) {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.LoadWithVersion(context.Background(), uid, version)
-}
-
-// LoadAll{{.StorageName}}sWithVersion retrieves all {{.Name}} resources in the requested schema version.
-//
-// Parameters:
-//   - version: Requested schema version (e.g., "v1", "v2beta1")
-//
-// Returns:
-//   - []interface{}: Slice of {{.Name}} resources in requested version
-//   - error: Error if version not supported
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).LoadAllWithVersion(ctx, version).
-//
-// Example:
-//   resources, err := storage.LoadAll{{.StorageName}}sWithVersion("v2beta1")
-//   if err != nil {
-//       return err
-//   }
-//   for _, r := range resources {
-//       if {{camelCase .Name}}V2, ok := r.(*{{toLower .PackageAlias}}v2beta1.{{.Name}}); ok {
-//           // Use v2beta1 resource
-//       }
-//   }
-func LoadAll{{.StorageName}}sWithVersion(version string) ([]interface{}, error) {
-    ensureDefaultBackend()
-    storage := Get{{.Name}}Storage(DefaultBackend)
-
-    results, err := storage.LoadAll(context.Background())
-    if err != nil {
-        return nil, err
-    }
-
-    typedResults := make([]{{.TypeName}}, len(results))
-    for i, res := range results {
-        typedRes, ok := res.({{.TypeName}})
-        if !ok {
-            return nil, fmt.Errorf("unexpected type in slice at index %d: got %T, want {{.TypeName}}", i, res)
-        }
-        typedResults[i] = typedRes
-    }
-
-    return typedResults, nil
-}
-
-// Save{{.StorageName}}WithVersion stores a {{.Name}} resource with version information.
-//
-// Parameters:
-//   - {{camelCase .Name}}: The {{.Name}} resource to save (can be any supported version)
-//   - version: Schema version of the provided resource
-//
-// Returns:
-//   - error: Any error that occurred during saving
-//
-// The storage backend will convert the resource to the storage version if needed.
-//
-// This is a convenience function that uses storage.DefaultBackend.
-// For more control, use storage.Get{{.Name}}Storage(backend).SaveWithVersion(ctx, resource, version).
-func Save{{.StorageName}}WithVersion({{camelCase .Name}} interface{}, version string) error {
-	ensureDefaultBackend()
-	storage := Get{{.Name}}Storage(DefaultBackend)
-	return storage.SaveWithVersion(context.Background(), {{camelCase .Name}}, version)
-}
-
-{{end}}
-
-// SetDefaultBackend sets the storage backend used by package-level convenience functions.
-//
-// Parameters:
-//   - backend: The StorageBackend implementation to use
-//
-// This function should be called during application initialization before
-// any storage operations are performed.
-//
-// Example:
-//   backend, err := storage.NewFileBackend("./data")
-//   if err != nil {
-//       log.Fatal(err)
-//   }
-//   storage.SetDefaultBackend(backend)
-func SetDefaultBackend(backend StorageBackend) {
-	DefaultBackend = backend
-}
-
-// GetDefaultBackend returns the current default storage backend.
-// If no backend has been set, it initializes a file-based backend.
-//
-// Returns:
-//   - StorageBackend: The current default backend
-func GetDefaultBackend() StorageBackend {
-	ensureDefaultBackend()
-	return DefaultBackend
-}
-
-{{range .Resources}}
-type {{.Name}}Storage struct {
-    GenericStorage
-}
-
-func Get{{.Name}}Storage(backend StorageBackend) *{{.Name}}Storage {
-    return &{{.Name}}Storage{
-        GenericStorage: backend.ForType("{{.Name}}"),
-    }
-}
-{{end}}
-
+// GenericStorage defines the interface for resource-specific storage operations.
 type GenericStorage interface {
 	Load(ctx context.Context, uid string) (interface{}, error)
 	LoadAll(ctx context.Context) ([]interface{}, error)
@@ -309,4 +36,139 @@ type GenericStorage interface {
 	LoadWithVersion(ctx context.Context, uid string, version string) (interface{}, string, error)
 	LoadAllWithVersion(ctx context.Context, version string) ([]interface{}, error)
 	SaveWithVersion(ctx context.Context, resource interface{}, version string) error
+}
+
+{{range .Resources}}
+// {{.Name}}Storage provides type-safe storage operations for {{.Name}} resources.
+type {{.Name}}Storage struct {
+	GenericStorage
+}
+
+// Get{{.Name}}Storage returns a type-safe storage interface for {{.Name}} resources.
+func Get{{.Name}}Storage(backend StorageBackend) *{{.Name}}Storage {
+	return &{{.Name}}Storage{
+		GenericStorage: backend.ForType("{{.Name}}"),
+	}
+}
+{{end}}
+
+// DefaultBackend is the storage backend used by the package-level convenience functions.
+var DefaultBackend StorageBackend
+var initOnce sync.Once
+
+func ensureDefaultBackend() {
+	initOnce.Do(func() {
+		if DefaultBackend == nil {
+			backend, err := NewFileBackend("inventory")
+			if err != nil {
+				panic(fmt.Sprintf("failed to initialize default storage backend: %v", err))
+			}
+			DefaultBackend = backend
+		}
+	})
+}
+
+// Package-level convenience functions for each resource type.
+{{range .Resources}}
+// LoadAll{{.StorageName}}s retrieves all {{.Name}} resources using the default backend.
+func LoadAll{{.StorageName}}s() ([]{{.TypeName}}, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	
+	results, err := storage.LoadAll(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	typedResults := make([]{{.TypeName}}, len(results))
+	for i, res := range results {
+		typedRes, ok := res.({{.TypeName}})
+		if !ok {
+			return nil, fmt.Errorf("unexpected type in slice at index %d: got %T, want {{.TypeName}}", i, res)
+		}
+		typedResults[i] = typedRes
+	}
+
+	return typedResults, nil
+}
+
+// Load{{.StorageName}} retrieves a single {{.Name}} resource by UID using the default backend.
+func Load{{.StorageName}}(uid string) ({{.TypeName}}, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+
+	res, err := storage.Load(context.Background(), uid)
+	if err != nil {
+		return nil, err
+	}
+
+	typedRes, ok := res.({{.TypeName}})
+	if !ok {
+		return nil, fmt.Errorf("unexpected type: got %T, want {{.TypeName}}", res)
+	}
+
+	return typedRes, nil
+}
+
+// Save{{.StorageName}} stores a {{.Name}} resource using the default backend.
+func Save{{.StorageName}}({{camelCase .Name}} {{.TypeName}}) error {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.Save(context.Background(), {{camelCase .Name}})
+}
+
+// Delete{{.StorageName}} removes a {{.Name}} resource by UID using the default backend.
+func Delete{{.StorageName}}(uid string) error {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.Delete(context.Background(), uid)
+}
+
+// Exists{{.StorageName}} checks if a {{.Name}} resource exists using the default backend.
+func Exists{{.StorageName}}(uid string) (bool, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.Exists(context.Background(), uid)
+}
+
+// List{{.StorageName}}UIDs returns UIDs of all {{.Name}} resources using the default backend.
+func List{{.StorageName}}UIDs() ([]string, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.List(context.Background())
+}
+
+// Load{{.StorageName}}WithVersion retrieves a single {{.Name}} resource in the requested schema version.
+func Load{{.StorageName}}WithVersion(uid string, version string) (interface{}, string, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.LoadWithVersion(context.Background(), uid, version)
+}
+
+// LoadAll{{.StorageName}}sWithVersion retrieves all {{.Name}} resources in the requested schema version.
+func LoadAll{{.StorageName}}sWithVersion(version string) ([]interface{}, error) {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	// This function's signature requires returning []interface{}, so we pass the result directly.
+	// The caller is responsible for type assertion.
+	return storage.LoadAllWithVersion(context.Background(), version)
+}
+
+// Save{{.StorageName}}WithVersion stores a {{.Name}} resource with version information.
+func Save{{.StorageName}}WithVersion({{camelCase .Name}} interface{}, version string) error {
+	ensureDefaultBackend()
+	storage := Get{{.Name}}Storage(DefaultBackend)
+	return storage.SaveWithVersion(context.Background(), {{camelCase .Name}}, version)
+}
+{{end}}
+
+// SetDefaultBackend sets the storage backend used by package-level convenience functions.
+func SetDefaultBackend(backend StorageBackend) {
+	DefaultBackend = backend
+}
+
+// GetDefaultBackend returns the current default storage backend.
+func GetDefaultBackend() StorageBackend {
+	ensureDefaultBackend()
+	return DefaultBackend
 }

--- a/pkg/codegen/templates/storage.go.tmpl
+++ b/pkg/codegen/templates/storage.go.tmpl
@@ -286,3 +286,27 @@ func GetDefaultBackend() StorageBackend {
 	ensureDefaultBackend()
 	return DefaultBackend
 }
+
+{{range .Resources}}
+type {{.Name}}Storage struct {
+    GenericStorage
+}
+
+func Get{{.Name}}Storage(backend StorageBackend) *{{.Name}}Storage {
+    return &{{.Name}}Storage{
+        GenericStorage: backend.ForType("{{.Name}}"),
+    }
+}
+{{end}}
+
+type GenericStorage interface {
+	Load(ctx context.Context, uid string) (interface{}, error)
+	LoadAll(ctx context.Context) ([]interface{}, error)
+	Save(ctx context.Context, resource interface{}) error
+	Delete(ctx context.Context, uid string) error
+	Exists(ctx context.Context, uid string) (bool, error)
+	List(ctx context.Context) ([]string, error)
+	LoadWithVersion(ctx context.Context, uid string, version string) (interface{}, string, error)
+	LoadAllWithVersion(ctx context.Context, version string) ([]interface{}, error)
+	SaveWithVersion(ctx context.Context, resource interface{}, version string) error
+}


### PR DESCRIPTION
# Motivation and Changes
When following the development guide, I noticed some things were hard coded and non-standard types were not handled correctly. To solve this:
- got rid of hardcoded switch statement in `generator.go`
- updated the storage template to be generic, rather than hardcoded for initial types (e.g., BMC, FRU, etc)
- removed the code that was hardcoded for the types provided already (BMC, fru, etc.) to make it more generic
- added a `genericFileBackend` that generates UIDs 
- removed some hardcoded functions in `interfaces.go`

And, finally, I updated the documentation to account for an additional step that was needed and then added a curl command with sample output.

# Testing

Tested this with:
1. created `pkg/resources/newtype/newtype.go`
```go
package newtype

import "github.com/openchami/inventory/pkg/resources"

type NewType struct {
	resources.Resource
	Spec   NewTypeSpec   `json:"spec"`
	Status NewTypeStatus `json:"status,omitempty"`
}

type NewTypeSpec struct {
	fieldOne string `json:"fieldOne"`
	fieldTwo string `json:"fieldTwo"`
}

type NewTypeStatus struct {
	Conditions []resources.Condition `json:"conditions,omitempty"`
}

```

2. added to `cmd/codegen/main.go`
```go
if err := generator.RegisterResource(&newtype.NewType{}); err != nil {
    log.Fatalf("Failed to register NewType resource: %v", err)
}
```

3. added to `pkg/resources/main.go`
```go
RegisterResourcePrefix("NewType", "nt")
```

4. `make dev`
5. `./bin/server`
6. Ran `$ curl -X POST -H "Content-Type: application/json" -d '{"name": "MyTestObject", "spec": {"fieldOne": "hello", "fieldTwo": "world"}}' http://localhost:8080/newtypes`
Which returned:
```json
{"apiVersion":"v1","kind":"NewType","schemaVersion":"v1","metadata":{"name":"MyTestObject","uid":"nt-d67c06b1","createdAt":"2025-10-03T14:02:00.257301-07:00","updatedAt":"2025-10-03T14:02:00.257301-07:00"},"spec":{},"status":{"conditions":[{"type":"Created","status":"True","reason":"NewTypeCreated","message":"NewType has been created","lastTransitionTime":"2025-10-03T14:02:00.257302-07:00"}]}}
```